### PR TITLE
Change group id to io.brooklyn.alfresco

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.brooklyncentral.alfresco</groupId>
+    <groupId>io.brooklyn.alfresco</groupId>
     <artifactId>brooklyn-alfresco</artifactId>
     <version>1.0.0-SNAPSHOT</version>
     


### PR DESCRIPTION
We don't own `io.brooklyncentral.*` group id on sonatype