### PR TITLE
Fix download url

### DIFF
--- a/catalog/alfresco/alfresco.bom
+++ b/catalog/alfresco/alfresco.bom
@@ -186,7 +186,6 @@ brooklyn.catalog:
             ALFRESCO_BASEUNIXSERVICE_SCRIPT_NAME: $brooklyn:config("alfresco.base.unix.service.script.name")
             ALFRESCO_SERVICES_STARTUP: $brooklyn:config("alfresco.services.startup")
           install.command: |
-            sudo yum update -y
             sudo yum install -y curl augeas java-1.8.0-openjdk
             curl --retry 5 --keepalive-time 30 --speed-time 30 -L "${ALFRESCO_DOWNLOAD_URL}" --output ${INSTALL_DIR}/alfresco-community-installer-linux-x64.bin
             chmod u+x ${INSTALL_DIR}/alfresco-community-installer-linux-x64.bin

--- a/catalog/alfresco/alfresco.bom
+++ b/catalog/alfresco/alfresco.bom
@@ -155,7 +155,7 @@ brooklyn.catalog:
           description: |
             The Alfresco download url
           type: string
-          default: "http://eu.dl.alfresco.com.s3.amazonaws.com/release/community/201702-build-00016/alfresco-community-installer-201702-linux-x64.bin"
+          default: "https://download.alfresco.com/release/community/201707-build-00028/alfresco-community-installer-201707-linux-x64.bin"
 
         brooklyn.config:
           shell.env:
@@ -187,7 +187,7 @@ brooklyn.catalog:
             ALFRESCO_SERVICES_STARTUP: $brooklyn:config("alfresco.services.startup")
           install.command: |
             sudo yum update -y
-            sudo yum install -y augeas java-1.8.0-openjdk
+            sudo yum install -y curl augeas java-1.8.0-openjdk
             curl --retry 5 --keepalive-time 30 --speed-time 30 -L "${ALFRESCO_DOWNLOAD_URL}" --output ${INSTALL_DIR}/alfresco-community-installer-linux-x64.bin
             chmod u+x ${INSTALL_DIR}/alfresco-community-installer-linux-x64.bin
             function writeAlfrescoInstallProperty(){

--- a/tests/alfresco/alfresco.tests.bom
+++ b/tests/alfresco/alfresco.tests.bom
@@ -14,7 +14,7 @@ brooklyn.catalog:
           - type: alfresco
             id: alfresco
             brooklyn.config:
-              alfresco.admin.password: p@55w0rd
+              alfresco.admin.password: fTdXknM2DsjzCHDRoJMTq9aG
           - type: test-case
             name: "Alfresco Community Edition Tests"
             brooklyn.config:


### PR DESCRIPTION
The old download url gave `403 Forbidden`, with the file containing:
```
<?xml version="1.0" encoding="UTF-8"?>
<Error><Code>AccessDenied</Code><Message>Access Denied</Message><RequestId>47F03FC6DF037FBF</RequestId><HostId>k74KKBJhoOkCuw/AbSH9eASauV5ZZ4UHEk0WQtQbU+T4vjKcf4JS1Eg7XE2CI0ZmE9V1StWnwWg=</HostId></Error>
```